### PR TITLE
use curtsies bpython instead of curses

### DIFF
--- a/trepan/processor/command/bpy.py
+++ b/trepan/processor/command/bpy.py
@@ -89,12 +89,16 @@ Use dbgr(*string*) to issue debugger command: *string*'''
             pass
 
         sys.ps1 = 'trepan2 >>> '
+        print banner
         try:
-            import bpython
-            bpython.embed(my_locals, ['-i'], banner=banner)
+            from bpython.curtsies import main as main_bpython
         except ImportError:
             return
 
+        try:
+            main_bpython([], my_locals)
+        except SystemExit:
+            pass
 
         # restore completion and our history if we can do so.
         if hasattr(self.proc.intf[-1], 'complete'):


### PR DESCRIPTION
Hi Rocky - here's a possibly solution to using bpython. (not requesting a merge necessarily, just sharing the idea) It's lower-level than embed and it uses with the new frontend that doesn't work on Windows. (not sure if that's a goal of your project) This is working with the last released version of bpython now, let me know what you think. In master bpython catching the SystemExit is no longer necessary, but with the currently released version it's necessary.

Many of the issues you mention in your email to the bpython list are still present, happy to discuss there here or there. FWIW I agree on the globals/locals,

>The last problem is a more minor. embed() has a parameter to set locals, but none to set globals. I suppose I could fold or put all globals variables into the local scope. But aside from being ugly and potentially time consuming, it's semantically wrong. 

I'm not sure what you mean by
>The second problem I encounter is in running callbacks into the debugger such as for listing files, changing frames for evaluation and so on. I get no output, unless I add a gratuitous print('') statement. And even then I am getting line feeds (\n) without a carriage return. What's going on there?

and am curious to hear if this is better or worse with this code.