### PR TITLE
fix conversion

### DIFF
--- a/trepan/processor/command/info_subcmd/args.py
+++ b/trepan/processor/command/info_subcmd/args.py
@@ -54,7 +54,7 @@ See also:
                 name = co.co_varnames[i]
                 self.msg_nocr("%d: %s = " % (i+1, name))
                 if name in d:
-                    self.msg(d[name])
+                    self.msg(str(d[name]))
                 else:
                     self.ermsg("undefined")
                     pass


### PR DESCRIPTION
info args fails when not implicit string conversion exists