### PR TITLE
support for split long messages server->client

### DIFF
--- a/trepan/inout/tcpclient.py
+++ b/trepan/inout/tcpclient.py
@@ -94,7 +94,16 @@ class TCPClient(DebuggerInOutBase):
                     self.state = 'disconnected'
                     raise EOFError
                 pass
-            self.buf, data = Mtcpfns.unpack_msg(self.buf)
+            self.buf, data, length = Mtcpfns.unpack_msg_segment(self.buf)
+            if len(data) == length:
+                return data
+            while len(data) < length:
+                data += self.inout.recv(Mtcpfns.TCP_MAX_PACKET)
+                if 0 == (self.buf):
+                    self.state = 'disconnected'
+                    raise EOFError
+            self.buf = data[length:]
+            data = data[:length]
             return data
         else:
             raise IOError("read_msg called in state: %s." % self.state)

--- a/trepan/inout/tcpfns.py
+++ b/trepan/inout/tcpfns.py
@@ -16,11 +16,11 @@
 """Subsidiary routines used to "pack" and "unpack" TCP messages. """
 
 TCP_MAX_PACKET = 8192  # Largest size for a recv
-LOG_MAX_MSG    = 4     # int(log(TCP_MAX_PACKET)
+LOG_MAX_MSG    = 8     # int(log(TCP_MAX_PACKET)) # big packet
 
 
 def pack_msg(msg):
-    fmt = '%%0%dd' % LOG_MAX_MSG  # A funny way of writing: '%04d'
+    fmt = '%%0%dd' % LOG_MAX_MSG  # A funny way of writing: '%08d'
     return ( fmt % len(msg)) + msg
 
 
@@ -29,6 +29,12 @@ def unpack_msg(buf):
     data    = buf[LOG_MAX_MSG:LOG_MAX_MSG+length]
     buf     = buf[LOG_MAX_MSG+length:]
     return buf, data
+
+def unpack_msg_segment(buf):
+    length  = int(buf[0:LOG_MAX_MSG])
+    data    = buf[LOG_MAX_MSG:LOG_MAX_MSG+length]
+    buf     = buf[LOG_MAX_MSG+length:]
+    return buf, data, length
 
 # Demo
 if __name__=='__main__':

--- a/trepan/inout/tcpserver.py
+++ b/trepan/inout/tcpserver.py
@@ -137,7 +137,12 @@ class TCPServer(DebuggerInOutBase):
             self.wait_for_connect()
             pass
         # FIXME: do we have to check the size of msg and split output?
-        return self.conn.send(Mtcpfns.pack_msg(msg))
+        # FIXED: mv 13.01.16
+        buffer = Mtcpfns.pack_msg(msg)
+        while len(buffer) > Mtcpfns.TCP_MAX_PACKET:
+            self.conn.send(buffer[:Mtcpfns.TCP_MAX_PACKET])
+            buffer = buffer[Mtcpfns.TCP_MAX_PACKET:]
+        return self.conn.send(buffer)
 
 # Demo
 if __name__=='__main__':


### PR DESCRIPTION
I have found that many of my issues come from the  8192 limit. I've changed the tcp interface for suporting 8 digits length and handle message fragments from  server to client connection. I tested with up to 256k with success.