### PR TITLE
Fix Tutorial links

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -236,7 +236,7 @@ See Also
 .. _trepanning: https://rubygems.org/gems/trepanning
 .. _debuggers: https://metacpan.org/pod/Devel::Trepan
 .. _this: http://bashdb.sourceforge.net/pydb/features.html
-.. _Tutorial: https://github.com/rocky/python2-trepan/wiki/Tutorial
+.. _Tutorial: http://python2-trepan.readthedocs.io/en/latest/entry-exit.html
 .. |downloads| image:: https://img.shields.io/pypi/dd/trepan.svg
     :target: https://pypi.python.org/pypi/trepan
     :alt: Daily PyPI downloads

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -37,7 +37,7 @@ Indices and tables
 * :ref:`genindex`
 * :ref:`search`
 
-.. _Tutorial: https://github.com/rocky/python2-trepan/wiki/Tutorial
+.. _Tutorial: http://python2-trepan.readthedocs.io/en/latest/entry-exit.html
 .. _ipython-trepan: https://github.com/rocky/ipython-trepan
 .. _trepan3k: https://pypi.python.org/pypi/trepan3k
 .. _pydbgr: https://pypi.python.org/pypi/pydbgr

--- a/trepan/__init__.py
+++ b/trepan/__init__.py
@@ -21,7 +21,7 @@ A gdb-like debugger for Python 2.
 
 A command-line interface (CLI) is provided.
 
-See the `Tutorial <https://github.com/rocky/python2-trepan/wiki/Tutorial>`_ for how to use.
+See the `Tutorial <http://python2-trepan.readthedocs.io/en/latest/entry-exit.html>`_ for how to use.
 
 Features
 ========


### PR DESCRIPTION
Make them point to "Entering the Trepan Debugger" - which already
feels like a tutorial.